### PR TITLE
36 mx library triplets bugfix

### DIFF
--- a/src/MXConverter.cpp
+++ b/src/MXConverter.cpp
@@ -1,4 +1,5 @@
 #include "MXConverter.h"
+#include "Log.h"
 #include <set>
 using namespace noteenums;
 extern std::set<std::string> DEFINITIVES;
@@ -66,6 +67,38 @@ const Duration MXConverter::ConvertDuration(mx::api::NoteData& n) {
 		case mx::api::DurationName::dur64th:
 			return Duration::SixtyFourth;
 		default:
-			throw ConversionException("Duration not found.", n); 
+			mfpg_log::Log::verbose_out(std::cout,
+				"No Duration Name was specified, defaulting to duration time tick...\n",
+				mfpg_log::VERBOSE_LEVEL::VERBOSE_ALL
+				);
+			break;
+	}
+	int t = n.durationData.durationTimeTicks;
+	if (t <= 3840 && t > 1920) {
+		return Duration::DoubleDur;
+	}
+	else if (t <= 1920 && t > 960) {
+		return Duration::Whole;
+	}
+	else if (t <= 960 && t > 480) {
+		return Duration::Half;
+	}
+	else if (t <= 480 && t > 240) {
+		return Duration::Quarter;
+	}
+	else if (t <= 240 && t > 120) {
+		return Duration::Eighth;
+	}
+	else if (t <= 120 && t > 60) {
+		return Duration::Sixteenth;
+	}
+	else if (t <= 60 && t > 30) {
+		return Duration::ThirtySecond;
+	}
+	else if (t <= 30 && t > 15) {
+		return Duration::SixtyFourth;
+	}
+	else {
+		throw ConversionException("Duration not found.", n);
 	}
 }

--- a/src/NoteAttributes.h
+++ b/src/NoteAttributes.h
@@ -7,6 +7,8 @@
 #include "NoteEnums.h"
 #include "SimplifiedNote.h"
 
+//Wrapper for containing physical attribute maps and definitive attributes in the same
+//structure
 class NoteAttributes {
 	private:	
 		const PhysAttrMap& phys_attr;
@@ -15,6 +17,7 @@ class NoteAttributes {
 		NoteAttributes() = delete; 
 		NoteAttributes(const PhysAttrMap&, const SimplifiedNote&); 
 		const PhysAttrMap& getPhysAttr();
+		//Definitives
 		const noteenums::Note& getNote();
 		const noteenums::Duration& getDuration();
 };

--- a/src/NoteList.cpp
+++ b/src/NoteList.cpp
@@ -4,20 +4,22 @@ using namespace std;
 using namespace mx::api;
 using it = std::list<SimplifiedNote>::const_iterator;
 
-NoteList::NoteList(const ScoreData& score) : notes(loadNotes(score)) {}
+NoteList::NoteList() : notes() {};
 
-const std::list<SimplifiedNote> NoteList::loadNotes(const ScoreData& score) {
-	std::list<SimplifiedNote> ret;
+NoteList::NoteList(const ScoreData& score) {
+	loadNotes(score);
+}
+
+const void NoteList::loadNotes(const ScoreData& score) {
 	for (PartData p: score.parts) {
 		for (MeasureData m: p.measures) {
 			for (StaffData s: m.staves) {
 				for (NoteData n: s.voices.at(0).notes) {
-					ret.push_back(n);
+					notes.push_back(n);
 				}
 			}
 		}
 	}
-	return ret;
 }
 
 int NoteList::size() const {

--- a/src/NoteList.h
+++ b/src/NoteList.h
@@ -9,15 +9,15 @@
 class NoteList {
 	private:
 		//List of notes in simplified form in the score.
-		const std::list<SimplifiedNote> notes;
+		std::list<SimplifiedNote> notes;
 
-		//Load notes into the list from the score.
-		const std::list<SimplifiedNote> loadNotes(const mx::api::ScoreData&);
 	public:
-		NoteList() = delete;
+		NoteList();
 		NoteList(const mx::api::ScoreData&);
 		
 		int size() const;
+		//Load notes into the list from the score.
+		const void loadNotes(const mx::api::ScoreData&);
 		
 		const SimplifiedNote& front() const;
 		const std::list<SimplifiedNote>& getNotes() const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -104,12 +104,28 @@ int main (int argc, char *argv[]) {
 //------------------------- MX conversion --------------------------------
 
 	using namespace mx::api;
-	auto& mgr = DocumentManager::getInstance();
-	const auto documentID = mgr.createFromFile(score_path);
-	const auto score = mgr.getData(documentID);
-	mgr.destroyDocument(documentID);
-	const NoteList note_list(score);
+	NoteList note_list;
 
+	try {
+		auto& mgr = DocumentManager::getInstance();
+		const auto documentID = mgr.createFromFile(score_path);
+		const auto score = mgr.getData(documentID);
+		mgr.destroyDocument(documentID);
+		note_list.loadNotes(score);
+	} catch (ConversionException e) {
+		mfpg_log::Log::verbose_out(log, ("ERROR: Could not convert mx structure to notelist: " + 
+			e.what() + "\n"), 
+			mfpg_log::VERBOSE_LEVEL::VERBOSE_ERRORS);
+		return -1;
+	} catch (runtime_error e) {
+		mfpg_log::Log::verbose_out(log, ("ERROR: Could not parse musicXML score: " + 
+			std::string(e.what()) + " This could be an error related to how the score was " + 
+			"exported, see: " +
+			"https://rasmusthorsson.github.io/mfpg/info/issues for information regarding known"
+			+ " issues relating to this." + "\n"), 
+			mfpg_log::VERBOSE_LEVEL::VERBOSE_ERRORS);
+		return -1;
+	}
 //---------------------- Instrument creation ----------------------------
 	//Patchwork solution until fixed output typing.	
 	std::shared_ptr<Instrument<int>> violin_i;

--- a/tests/cmake_scripts/system_tests_DSL_one_with_defs_double.cmake
+++ b/tests/cmake_scripts/system_tests_DSL_one_with_defs_double.cmake
@@ -15,8 +15,8 @@ execute_process(
 execute_process(
 	COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${CMAKE_BINARY_DIR}/A_W_DSL_sps_with_defs.csv ${CMAKE_BINARY_DIR}/A_W_DSL_sps_with_defs_double.csv RESULT_VARIABLE A_W_sps_res)
 
-#file(REMOVE ${CMAKE_BINARY_DIR}/A_W_DSL_sps_with_defs_double.csv)
-#file(REMOVE ${CMAKE_BINARY_DIR}/A_W_DSL_sps_with_defs.csv)
+file(REMOVE ${CMAKE_BINARY_DIR}/A_W_DSL_sps_with_defs_double.csv)
+file(REMOVE ${CMAKE_BINARY_DIR}/A_W_DSL_sps_with_defs.csv)
 
 if (NOT A_W_sps_res)
 	message("csv match")

--- a/webdocs/mfpg/guides/cliguide.html
+++ b/webdocs/mfpg/guides/cliguide.html
@@ -75,6 +75,7 @@
             </div>
             <a href="/mfpg/info/patch-notes/">Patch Notes</a>
             <a href="/mfpg/info/faq">Frequently Asked Questions</a>
+            <a href="/mfpg/info/issues">Known Issues</a>
             <a href="/mfpg/info/technical-information">Technical Information</a>
           </div>
         </div>

--- a/webdocs/mfpg/guides/dslguide.html
+++ b/webdocs/mfpg/guides/dslguide.html
@@ -75,6 +75,7 @@
             </div>
             <a href="/mfpg/info/patch-notes/">Patch Notes</a>
             <a href="/mfpg/info/faq">Frequently Asked Questions</a>
+            <a href="/mfpg/info/issues">Known Issues</a>
             <a href="/mfpg/info/technical-information">Technical Information</a>
           </div>
         </div>

--- a/webdocs/mfpg/guides/example-easy.html
+++ b/webdocs/mfpg/guides/example-easy.html
@@ -75,6 +75,7 @@
             </div>
             <a href="/mfpg/info/patch-notes/">Patch Notes</a>
             <a href="/mfpg/info/faq">Frequently Asked Questions</a>
+            <a href="/mfpg/info/issues">Known Issues</a>
             <a href="/mfpg/info/technical-information">Technical Information</a>
           </div>
         </div>

--- a/webdocs/mfpg/guides/guiguide.html
+++ b/webdocs/mfpg/guides/guiguide.html
@@ -75,6 +75,7 @@
             </div>
             <a href="/mfpg/info/patch-notes/">Patch Notes</a>
             <a href="/mfpg/info/faq">Frequently Asked Questions</a>
+            <a href="/mfpg/info/issues">Known Issues</a>
             <a href="/mfpg/info/technical-information">Technical Information</a>
           </div>
         </div>

--- a/webdocs/mfpg/guides/index.html
+++ b/webdocs/mfpg/guides/index.html
@@ -75,6 +75,7 @@
             </div>
             <a href="/mfpg/info/patch-notes/">Patch Notes</a>
             <a href="/mfpg/info/faq">Frequently Asked Questions</a>
+            <a href="/mfpg/info/issues">Known Issues</a>
             <a href="/mfpg/info/technical-information">Technical Information</a>
           </div>
         </div>

--- a/webdocs/mfpg/guides/notemapbuilder.html
+++ b/webdocs/mfpg/guides/notemapbuilder.html
@@ -75,6 +75,7 @@
             </div>
             <a href="/mfpg/info/patch-notes/">Patch Notes</a>
             <a href="/mfpg/info/faq">Frequently Asked Questions</a>
+            <a href="/mfpg/info/issues">Known Issues</a>
             <a href="/mfpg/info/technical-information">Technical Information</a>
           </div>
         </div>

--- a/webdocs/mfpg/index.html
+++ b/webdocs/mfpg/index.html
@@ -75,6 +75,7 @@
             </div>
             <a href="/mfpg/info/patch-notes/">Patch Notes</a>
             <a href="/mfpg/info/faq">Frequently Asked Questions</a>
+            <a href="/mfpg/info/issues">Known Issues</a>
             <a href="/mfpg/info/technical-information">Technical Information</a>
           </div>
         </div>

--- a/webdocs/mfpg/info/faq.html
+++ b/webdocs/mfpg/info/faq.html
@@ -74,6 +74,7 @@
             </div>
             <a href="/mfpg/info/patch-notes/">Patch Notes</a>
             <a href="/mfpg/info/faq">Frequently Asked Questions</a>
+            <a href="/mfpg/info/issues">Known Issues</a>
             <a href="/mfpg/info/technical-information">Technical Information</a>
           </div>
         </div>

--- a/webdocs/mfpg/info/index.html
+++ b/webdocs/mfpg/info/index.html
@@ -74,6 +74,7 @@
             </div>
             <a href="/mfpg/info/patch-notes/">Patch Notes</a>
             <a href="/mfpg/info/faq">Frequently Asked Questions</a>
+            <a href="/mfpg/info/issues">Known Issues</a>
             <a href="/mfpg/info/technical-information">Technical Information</a>
           </div>
         </div>
@@ -97,6 +98,12 @@
       </div>
       <p style="text-align: center;">
         Page for frequently asked questions
+      </p>
+      <div class="links">
+        <a href="/mfpg/info/issues">Known Issues</a>
+      </div>
+      <p style="text-align: center;">
+        Known issues with usage
       </p>
       <div class="links">
         <a href="/mfpg/info/technical-information">Technical Information</a>

--- a/webdocs/mfpg/info/issues.html
+++ b/webdocs/mfpg/info/issues.html
@@ -20,7 +20,7 @@
         <button onclick="dropGuidesMenu()" class="dropbtn">
           &#11183
         </button>
-        <div id="guides" class="dropdown-menu">
+        <div id="guides" div class="dropdown-menu">
           <div class="dropdown-content">
             <div class="dropdown-text">
               Interfaces
@@ -43,7 +43,6 @@
           </div>
         </div>
       </div>
-
       <div class="menu">
         <button style="width: 75%;" class="btn">
           <a href="/mfpg/links/">Links</a>
@@ -51,7 +50,7 @@
         <button onclick="dropLinksMenu()" class="dropbtn">
           &#11183
         </button>
-        <div id="links" class="dropdown-menu">
+        <div id="links" div class="dropdown-menu">
           <div class="dropdown-content">
             <div class="dropdown-text">
               Links
@@ -60,6 +59,7 @@
           </div>
         </div>
       </div>
+      
       <div class="menu">
         <button style="width: 75%;" class="btn-selected">
           <a href="/mfpg/info/">Info</a> 
@@ -67,7 +67,7 @@
         <button onclick="dropInfoMenu()" class="dropbtn">
           &#11183
         </button>
-        <div id="info" class="dropdown-menu">
+        <div id="info" div class="dropdown-menu">
           <div class="dropdown-content">
             <div class="dropdown-text">
               Information
@@ -80,23 +80,24 @@
         </div>
       </div>
     </div>
-    <div class="quickbar">
-      <div class="quickbar-text">
-        Patch Notes
+    <div class="homemenu">
+      <div class="hometitle"> 
+        Known Issues
       </div>
-      <a href="/mfpg/info/patch-notes/patch-0-1" style="color:#a111f1;">Patch 0.1</a>
-    </div>
-    <div class="guidepage-index">
-      <a href="#">Placeholder</a>
-    </div>
-    <div class="guidepage">
-      <div class="pagetitle"> 
-        Placeholder Patch page
-      </div>
-      <div class="guidepage-text">
-        <h1>Placeholder</h1>
-        This is placeholder for patch pages.
-      </div>
+      <h1>
+        Noteflight musicXML Export
+      </h1>
+      <h3 align="center">
+        Noteflight exports <i>musicXML</i> files containing tuplets in an order not supported by the 
+        <b>mx</b> library. Currently it cannot successfully parse scores directly exported to 
+        <i>musicXML</i> by Noteflight.
+      </h3>
+      <p style="text-align: center;">
+      This can be solved by exporting the score as a <i>MIDI</i> file (or some other accepted export format
+      by Noteflight), and then using a converter to convert it to <i>musicXML</i>. This issue should be 
+      fixed in future updates where a converter is automatically used in the program when the file format
+      is not musicXML.
+      </p>
     </div>
   </body>
 </html>

--- a/webdocs/mfpg/info/patch-notes/index.html
+++ b/webdocs/mfpg/info/patch-notes/index.html
@@ -75,6 +75,7 @@
             </div>
             <a href="/mfpg/info/patch-notes/">Patch Notes</a>
             <a href="/mfpg/info/faq">Frequently Asked Questions</a>
+            <a href="/mfpg/info/issues">Known Issues</a>
             <a href="/mfpg/info/technical-information">Technical Information</a>
          </div>
         </div>

--- a/webdocs/mfpg/info/technical-information.html
+++ b/webdocs/mfpg/info/technical-information.html
@@ -74,6 +74,7 @@
             </div>
             <a href="/mfpg/info/patch-notes/">Patch Notes</a>
             <a href="/mfpg/info/faq">Frequently Asked Questions</a>
+            <a href="/mfpg/info/issues">Known Issues</a>
             <a href="/mfpg/info/technical-information">Technical Information</a>
           </div>
         </div>

--- a/webdocs/mfpg/links/index.html
+++ b/webdocs/mfpg/links/index.html
@@ -75,6 +75,7 @@
             </div>
             <a href="/mfpg/info/patch-notes/">Patch Notes</a>
             <a href="/mfpg/info/faq">Frequently Asked Questions</a>
+            <a href="/mfpg/info/issues">Known Issues</a>
             <a href="/mfpg/info/technical-information">Technical Information</a>
           </div>
         </div>


### PR DESCRIPTION
The problem was found to be in the export format of Noteflight in this case. An issues page was added to the webpage where these types of issues can be documented. Also added exception handling for conversion exceptions and MX exceptions. Added a workaround for when specific durations are not specified in the musicXML file which uses ticktimes instead, less accurate and speculative.