### PR TITLE
Gui hotfix tabs undo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,8 @@ add_executable(mfpg ${CLI_BASE})
 
 if (BUILD_GUI) 
   file(GLOB_RECURSE GUI_BASE src/gui/MFPG_Gui.cpp src/gui/MFPG_Frame.cpp src/gui/MFPG_Panel.cpp 
-	  src/gui/MFPG_Choicebook.cpp src/gui/MFPG_AdvFrame.cpp src/gui/Gui_Settings.cpp ${BASE})
+	  src/gui/MFPG_Choicebook.cpp src/gui/MFPG_AdvFrame.cpp src/gui/MFPG_Text.cpp 
+	  src/gui/Gui_Settings.cpp ${BASE})
   if(MSVC)
 	set(wxWidgets_ROOT_DIR ${WXW_ROOT_DIR})
 	set(wxWidgets_LIB_DIR ${WXW_LIB_DIR})

--- a/src/gui/MFPG_Panel.cpp
+++ b/src/gui/MFPG_Panel.cpp
@@ -1,4 +1,5 @@
 #include "MFPG_Panel.h"
+#include "MFPG_Text.h"
 #include "wx/xrc/xmlres.h"
 #include "wx/valtext.h"
 
@@ -37,16 +38,32 @@ void MFPG_Panel::InitPanel(bool use_xrc) {
 		save_file_button = XRCCTRL(*this, "ID_BTSavetext", wxButton);
 		save_as_file_button = XRCCTRL(*this, "ID_BTSaveastext", wxButton);
 		//Manually adding pages since wxUiEditor can not
+		output_text = new MFPG_Text(files_book, 
+				wxTE_LEFT|wxTE_MULTILINE|wxTE_DONTWRAP|wxTE_READONLY|wxTE_RICH2,
+				"OUTPUT_TEXT");
+		notemapper_text = new MFPG_Text(files_book, 
+				wxTE_LEFT|wxTE_MULTILINE|wxTE_DONTWRAP|wxTE_RICH2,
+				"NOTEMAPPER_TEXT");
+		dsl_text = new MFPG_Text(files_book,
+				wxTE_LEFT|wxTE_MULTILINE|wxTE_DONTWRAP|wxTE_RICH2, 
+				"OUTPUT_TEXT");
+		/*
 		output_text = new wxTextCtrl(files_book, wxID_ANY, "",  wxPoint(10, 10), wxSize(500, 520), 
 			wxTE_LEFT|wxTE_MULTILINE|wxTE_DONTWRAP|wxTE_READONLY, wxDefaultValidator, 
 			"OUTPUT_TEXT");
+		*/
 		output_text->Enable();
+		/*
 		notemapper_text = new wxTextCtrl(files_book, wxID_ANY, "",  wxPoint(10, 10), 
-				wxSize(500, 520), wxTE_LEFT|wxTE_MULTILINE|wxTE_DONTWRAP, wxDefaultValidator,
-				"NOTEMAPPER_TEXT");
+				wxSize(500, 520), wxTE_LEFT|wxTE_MULTILINE|wxTE_DONTWRAP|wxTE_PROCESS_TAB,
+				wxDefaultValidator, "NOTEMAPPER_TEXT");
+		*/
 		notemapper_text->Disable();
+		/*
 		dsl_text = new wxTextCtrl(files_book, wxID_ANY, "",  wxPoint(10, 10), wxSize(500, 520), 
-				wxTE_LEFT|wxTE_MULTILINE|wxTE_DONTWRAP, wxDefaultValidator, "DSL_TEXT");
+				wxTE_LEFT|wxTE_MULTILINE|wxTE_DONTWRAP|wxTE_PROCESS_TAB,
+				wxDefaultValidator, "DSL_TEXT");
+		*/
 		dsl_text->Disable();
 
 		files_book->AddPage(output_text, "Output", true, -1);

--- a/src/gui/MFPG_Panel.cpp
+++ b/src/gui/MFPG_Panel.cpp
@@ -39,13 +39,14 @@ void MFPG_Panel::InitPanel(bool use_xrc) {
 		save_as_file_button = XRCCTRL(*this, "ID_BTSaveastext", wxButton);
 		//Manually adding pages since wxUiEditor can not
 		output_text = new MFPG_Text(files_book, 
-				wxTE_LEFT|wxTE_MULTILINE|wxTE_DONTWRAP|wxTE_READONLY|wxTE_RICH2,
+				wxTE_LEFT|wxTE_MULTILINE|wxTE_DONTWRAP|wxTE_READONLY|wxTE_RICH2|
+				wxTE_PROCESS_TAB,
 				"OUTPUT_TEXT");
 		notemapper_text = new MFPG_Text(files_book, 
-				wxTE_LEFT|wxTE_MULTILINE|wxTE_DONTWRAP|wxTE_RICH2,
+				wxTE_LEFT|wxTE_MULTILINE|wxTE_DONTWRAP|wxTE_RICH2|wxTE_PROCESS_TAB,
 				"NOTEMAPPER_TEXT");
 		dsl_text = new MFPG_Text(files_book,
-				wxTE_LEFT|wxTE_MULTILINE|wxTE_DONTWRAP|wxTE_RICH2, 
+				wxTE_LEFT|wxTE_MULTILINE|wxTE_DONTWRAP|wxTE_RICH2|wxTE_PROCESS_TAB, 
 				"OUTPUT_TEXT");
 		/*
 		output_text = new wxTextCtrl(files_book, wxID_ANY, "",  wxPoint(10, 10), wxSize(500, 520), 

--- a/src/gui/MFPG_Text.cpp
+++ b/src/gui/MFPG_Text.cpp
@@ -9,15 +9,4 @@
 
 MFPG_Text::MFPG_Text(wxWindow* window, long style, std::string name) : wxTextCtrl(window, wxID_ANY, 
 		"", wxPoint(T_X, T_Y), wxSize(T_WIDTH, T_HEIGHT), style, wxDefaultValidator, name) {
-	this->Bind(wxEVT_CHAR, &MFPG_Text::keyUndo, this);
-}
-
-void MFPG_Text::keyUndo(wxKeyEvent& event) {
-	if ((event.GetEventType() == wxEVT_KEY_DOWN) || 
-		(((wxKeyEvent&)event).GetUnicodeKey() == WXK_CONTROL_Z)) {
-		this->Undo();
-		wxMessageBox("HELLO");
-		return;
-	}
-	event.Skip();
 }

--- a/src/gui/MFPG_Text.cpp
+++ b/src/gui/MFPG_Text.cpp
@@ -1,0 +1,23 @@
+#include "MFPG_Text.h"
+#include "wx/msgdlg.h"
+
+#define T_WIDTH 500
+#define T_HEIGHT 520
+
+#define T_X 10
+#define T_Y 10
+
+MFPG_Text::MFPG_Text(wxWindow* window, long style, std::string name) : wxTextCtrl(window, wxID_ANY, 
+		"", wxPoint(T_X, T_Y), wxSize(T_WIDTH, T_HEIGHT), style, wxDefaultValidator, name) {
+	this->Bind(wxEVT_CHAR, &MFPG_Text::keyUndo, this);
+}
+
+void MFPG_Text::keyUndo(wxKeyEvent& event) {
+	if ((event.GetEventType() == wxEVT_KEY_DOWN) || 
+		(((wxKeyEvent&)event).GetUnicodeKey() == WXK_CONTROL_Z)) {
+		this->Undo;
+		wxMessageBox("HELLO");
+		return;
+	}
+	event.Skip();
+}

--- a/src/gui/MFPG_Text.cpp
+++ b/src/gui/MFPG_Text.cpp
@@ -15,7 +15,7 @@ MFPG_Text::MFPG_Text(wxWindow* window, long style, std::string name) : wxTextCtr
 void MFPG_Text::keyUndo(wxKeyEvent& event) {
 	if ((event.GetEventType() == wxEVT_KEY_DOWN) || 
 		(((wxKeyEvent&)event).GetUnicodeKey() == WXK_CONTROL_Z)) {
-		this->Undo;
+		this->Undo();
 		wxMessageBox("HELLO");
 		return;
 	}

--- a/src/gui/MFPG_Text.h
+++ b/src/gui/MFPG_Text.h
@@ -1,0 +1,13 @@
+#ifndef MFPG_TEXT_H
+#define MFPG_TEXT_H
+
+#include <wx/textctrl.h>
+
+class MFPG_Text : public wxTextCtrl {
+	public:
+		MFPG_Text(wxWindow*, long, std::string);
+
+		void keyUndo(wxKeyEvent&);
+};
+
+#endif

--- a/src/gui/MFPG_Text.h
+++ b/src/gui/MFPG_Text.h
@@ -6,8 +6,6 @@
 class MFPG_Text : public wxTextCtrl {
 	public:
 		MFPG_Text(wxWindow*, long, std::string);
-
-		void keyUndo(wxKeyEvent&);
 };
 
 #endif


### PR DESCRIPTION
wxWidgets already has an implementation for undos, redos and tab implementation. The undos and redos are only implemented for MSW and macOS, and it is not worth the effort to implement them for linux as most use cases are expected to be for windows.